### PR TITLE
Fix relative_to_original_destination_root

### DIFF
--- a/lib/bundler/vendor/thor/lib/thor/actions.rb
+++ b/lib/bundler/vendor/thor/lib/thor/actions.rb
@@ -113,9 +113,11 @@ class Bundler::Thor
     # the script started).
     #
     def relative_to_original_destination_root(path, remove_dot = true)
-      path = path.dup
-      if path.gsub!(@destination_stack[0], ".")
-        remove_dot ? (path[2..-1] || "") : path
+      root = @destination_stack[0]
+      if path.start_with?(root) && [File::SEPARATOR, File::ALT_SEPARATOR, nil, ''].include?(path[0...root.size])
+        path = path.dup
+        path[0...root.size] = '.'
+        remove_dot ? (path[root.size..-1] || "") : path
       else
         path
       end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When I create a gem with the command `bundle gem`, I see the wrong output.
For example:
```bash
$ bundle gem test-gem
Creating gem 'test-gem'...
MIT License enabled in config
      create  est-gem.Gemfile
      create  est-gem.lib.test.gem.rb
      create  est-gem.lib.test.gem.version.rb
      create  est-gem.test-gem.gemspec
      create  est-gem.Rakefile
      create  est-gem.README.md
      create  est-gem.bin.console
      create  est-gem.bin.setup
      create  est-gem..gitignore
      create  est-gem.LICENSE.txt
Initializing git repo in /test-gem
Gem 'test-gem' was successfully created. For more information on making a RubyGem visit https://bundler.io/guides/creating_gem.html
```

### What was your diagnosis of the problem?

The problem in the wrong file name and path of new gem files.

### What is your fix for the problem, implemented in this PR?

I updated the method `relative_to_original_destination_root`.
I took as a basis this commit https://github.com/erikhuda/thor/commit/506950f59245ff0db3c7d6589fbfbd182cb20f0c#diff-f8ad773f327e75ac0dae88f03b0098d1 and I changed it a little.
